### PR TITLE
[WIP]ユーザー本人確認ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,4 @@
 @import 'login_users';
 @import '_reset';
 @import 'config/colors';
+@import 'confirm_users';

--- a/app/assets/stylesheets/confirm_users.scss
+++ b/app/assets/stylesheets/confirm_users.scss
@@ -1,0 +1,107 @@
+.mainframe{
+  background-color:white;
+  width:100%;
+  height:100%;
+
+  &__title{
+    padding:10px;
+    font-size:24px;
+    background-color:white;
+    color:#333333;
+    text-align:center;
+    border-bottom:medium solid #F5F5F5;
+    background-color:white;
+    margin-bottom:100px;
+  }
+  &__explain{
+    margin-top:100px;
+    margin: 0  auto;
+    left:0;
+    right:0;
+    width:80%;
+    line-height:150%;
+    &__upload{
+      text-align:right;
+      color:#1A99E8;
+      width:100%;
+      line-height:250%;
+    }
+  }
+  .contents{
+    margin:0 auto;
+    width:80%;
+    height:100%;
+    background-color:white;
+    left:0;
+    right:0;
+    top:0;
+    bottom:0;
+    &__certificationLink{
+      color:#1A99E8;
+      text-align:right;
+      line-height:250%;
+    }
+    &__informations{
+      &__information{
+        margin:50px 0;
+        b{
+          line-height:250%;
+        }
+      }
+    }
+    &__inputs{
+      &__unit{
+        margin:50px 0 0 0;
+        // background-color:red;
+        b{
+          line-height:250%;
+        }
+        span{
+          background-color:#CCCCCC;
+          color:white;
+          border-radius:3px;
+          padding:5px;
+          font-size:80%;
+        }
+        &__inputbox{
+          width:100%;
+          position:relative;
+          input,&__list{
+            width:100%;
+            border-radius:3px;
+            height:40px;
+            font-size:120%;
+          }
+          select{
+            appearance:none;
+            -webkit-appearance: none;/* ベンダープレフィックス(Google Chrome、Safari用) */
+            -webkit-appearance: none;/* ベンダープレフィックス(Google Chrome、Safari用) */
+          }
+          &__icon{
+            position:absolute;
+            right:7px;
+            top:10px;
+            font-size:150%;
+            z-index:5;
+            color:#888888;
+          }
+
+          &__registerButton{
+            background-color:red;
+            color:white;
+            line-height:400%;
+            text-align:center;
+            width:100%;
+          }
+          &__registerLink{
+            color:#1A99E8;
+            text-align:right;
+            width:100%;
+            margin:40px 0;
+            // background-color:red;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,5 +11,3 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = yield
-    %div
-      Hello, World!!

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,2 +1,103 @@
-%div
-  Hello world
+.mainframe
+  .mainframe__title
+    %b 本人情報の登録
+  .mainframe__explain
+    %p.contents__explain__one お客さまの本人情報をご登録ください。 
+    %p.contents__explain__one 登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+    .mainframe__explain__upload
+      %p 本人確認書類のアップロードについて>
+  .contents
+    .contents__informations
+      .contents__informations__information
+        %b お名前
+        %p 山田　太郎
+      .contents__informations__information
+        %b お名前カナ
+        %p ヤマダ　タロウ
+      .contents__informations__information
+        %b 生年月日
+        %p 1990/01/01
+
+    .contents__inputs
+      .contents__inputs__unit
+        %b 郵便番号
+        %span 任意
+        .contents__inputs__unit__inputbox
+          %input{placeholder:'例)1234567'}
+      .contents__inputs__unit
+        %b 都道府県
+        %span 任意
+        .contents__inputs__unit__inputbox
+          %select{name:"prefecture",class:"contents__inputs__unit__inputbox__list "}
+            %option　北海道
+            %option　青森県
+            %option　岩手県
+            %option　宮城県
+            %option　秋田県
+            %option　山形県
+            %option　福島県
+            %option　東京都
+            %option　神奈川県
+            %option　埼玉県
+            %option　千葉県
+            %option　茨城県
+            %option　栃木県
+            %option　群馬県
+            %option　山梨県
+            %option　新潟県
+            %option　長野県
+            %option　富山県
+            %option　石川県
+            %option　福井県
+            %option　愛知県
+            %option　岐阜県
+            %option　静岡県
+            %option　三重県
+            %option　大阪府
+            %option　兵庫県
+            %option　京都府
+            %option　滋賀県
+            %option　奈良県
+            %option　和歌山県
+            %option　鳥取県
+            %option　島根県
+            %option　岡山県
+            %option　広島県
+            %option　山口県
+            %option　徳島県
+            %option　徳島県
+            %option　香川県
+            %option　愛媛県
+            %option　高知県
+            %option　福岡県
+            %option　佐賀県
+            %option　長崎県
+            %option　熊本県
+            %option　大分県
+            %option　宮崎県
+            %option　鹿児島県
+            %option　沖縄県
+          %i.fas.fa-chevron-down.contents__inputs__unit__inputbox__icon
+      .contents__inputs__unit
+        %b 市区町村
+        %span 任意
+        .contents__inputs__unit__inputbox
+          %input{placeholder:'例)横浜市緑区'}
+      .contents__inputs__unit
+        %b 番地
+        %span 任意
+        .contents__inputs__unit__inputbox
+          %input{placeholder:'例)青山1-1-1'}
+      .contents__inputs__unit
+        %b 建物名
+        %span 任意
+        .contents__inputs__unit__inputbox
+          %input{placeholder:'例)柳ビル103'}
+      .contents__inputs__unit
+        .contents__inputs__unit__inputbox
+          .contents__inputs__unit__inputbox__registerButton
+            登録する
+          .contents__inputs__unit__inputbox__registerLink
+            本人情報の登録について>
+
+    //後々部分テンプレートにする


### PR DESCRIPTION
# 目的
Trelloのタスクのうちの１つを片付ける

# スケジュール
出来るだけ早くLGTMを貰う。

# 達成条件
本家とほぼ同じ見た目になる。
リンクはまだ貼らない。

# 実装の概要
部分テンプレートにして、パンくずやヘッダーを含んだものと、統合するつもりである。

# 不安に思っていること
統合後、レイアウトが崩れないかどうか。

# 保留してること
リンクはまだ貼っていない。
データベースに登録したりするのも、まだ。
見た目のみ。