### PR TITLE
[WIP]商品出品：画像投稿機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,4 @@ gem 'enum_help'
 gem 'rails-i18n'
 gem 'fog-aws'
 gem 'pry-byebug'
+gem 'aws-sdk-s3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,22 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.199.0)
+    aws-sdk-core (3.62.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.24.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.46.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.4)
@@ -172,6 +188,7 @@ GEM
     ipaddress (0.8.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
+    jmespath (1.4.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -369,6 +386,7 @@ PLATFORMS
 DEPENDENCIES
   active_hash
   ancestry
+  aws-sdk-s3
   bootsnap (>= 1.1.0)
   byebug
   capistrano

--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -1,0 +1,18 @@
+$(document).on('turbolinks:load', function() { 
+
+  $(function(){
+    $('#pic_upload').change(function(e){
+      var files = e.target.files;
+      console.log(files)
+    })
+
+  })
+
+
+
+
+
+
+
+
+})

--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -2,17 +2,24 @@ $(document).on('turbolinks:load', function() {
 
   $(function(){
     $('#pic_upload').change(function(e){
-      var files = e.target.files;
-      console.log(files)
+      var files = e.target.files[0];
+      var reader = new FileReader();
+      $preview = $(".preview");
+      t = this;
     })
 
-  })
+    reader.onload = (function(files){
+      return function(e){
+      $preview.append($('img')).attr({
+        src: e.target.result,
+        width: "150px",
+        class: "preview",
+        title: file.name
+        });
+      };
+    })(files);
 
+    reader.readAsDataURL(files);
+  });
 
-
-
-
-
-
-
-})
+});

--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -3,23 +3,19 @@ $(document).on('turbolinks:load', function() {
   $(function(){
     $('#pic_upload').change(function(e){
       var files = e.target.files[0];
-      var reader = new FileReader();
-      $preview = $(".preview");
-      t = this;
+      var blobUrl = window.URL.createObjectURL(files);
+
+      var img = $(`<li class="upload__image">
+                  <img id="preview-image">
+                  <div class="upload__image__btn">
+                    <a class="remove-btn" data-id="">削除</a>
+                  </div> 
+                </li>`);
+      
+      $('#preview-image').attr('src', blobUrl);
     })
 
-    reader.onload = (function(files){
-      return function(e){
-      $preview.append($('img')).attr({
-        src: e.target.result,
-        width: "150px",
-        class: "preview",
-        title: file.name
-        });
-      };
-    })(files);
 
-    reader.readAsDataURL(files);
   });
 
 });

--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -1,21 +1,31 @@
 $(document).on('turbolinks:load', function() { 
 
   $(function(){
+
+    function buildImgHtml(blobUrl){
+      var image = `<img src="${blobUrl}" id="preview-image">`;
+      return image;
+    }
+
+    function appendImgBox(insertImg){
+      var imagePreviewHtlm = '';
+      imagePreviewHtlm = `<div class="upload__image">
+                            ${insertImg}
+                            <div class="upload__image__btn">
+                              <a class="remove-btn">削除</a>
+                          </div>`
+      $(imagePreviewHtlm).insertAfter('.upload__images');
+    }
+
+
     $('#pic_upload').change(function(e){
       var files = e.target.files[0];
       var blobUrl = window.URL.createObjectURL(files);
 
-      var img = $(`<div class="upload__image">
-                    <img id="preview-image">
-                    <div class="upload__image__btn">
-                      <a class="remove-btn">削除</a>
-                  </div> 
-                </li>`);
-      
-      $('#preview-image').attr('src', blobUrl);
-    })
-
-
+      insertImg = buildImgHtml(blobUrl);
+      appendImgBox(insertImg);
+    });
+    
+  
   });
-
 });

--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -1,20 +1,23 @@
 $(document).on('turbolinks:load', function() { 
 
   $(function(){
-
+    var itemNum = 1;
+    // 画像URLをセッティング
     function buildImgHtml(blobUrl){
       var image = `<img src="${blobUrl}" id="preview-image">`;
       return image;
     }
 
+    // 画像+ボタンのひとかたまりを作る
     function appendImgBox(insertImg){
       var imagePreviewHtlm = '';
       imagePreviewHtlm = `<div class="upload__image">
                             ${insertImg}
                             <div class="upload__image__btn">
-                              <a class="remove-btn">削除</a>
-                          </div>`
-      $(imagePreviewHtlm).insertAfter('.upload__images');
+                              <a class="remove-btn">削除</a></div></div>
+                          <input multiple= "multiple" name="product[images][]" class="upload-image" data-image= "${itemNum}" type="file" id="pic_upload${itemNum}" style= "display: none;">
+                          <div class="sell-upload-drop-box" onclick= "$('#pic_upload${itemNum}').click()"></div>`
+      $(imagePreviewHtlm).appendTo('.select-large-box');
     }
 
 
@@ -22,10 +25,13 @@ $(document).on('turbolinks:load', function() {
       var files = e.target.files[0];
       var blobUrl = window.URL.createObjectURL(files);
 
+
       insertImg = buildImgHtml(blobUrl);
       appendImgBox(insertImg);
+      $('.sell-upload-drop-box.have-item-0').css('display', 'none');
+ 
     });
-    
+
   
   });
 });

--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -5,10 +5,10 @@ $(document).on('turbolinks:load', function() {
       var files = e.target.files[0];
       var blobUrl = window.URL.createObjectURL(files);
 
-      var img = $(`<li class="upload__image">
-                  <img id="preview-image">
-                  <div class="upload__image__btn">
-                    <a class="remove-btn" data-id="">削除</a>
+      var img = $(`<div class="upload__image">
+                    <img id="preview-image">
+                    <div class="upload__image__btn">
+                      <a class="remove-btn">削除</a>
                   </div> 
                 </li>`);
       

--- a/app/assets/stylesheets/noveus.scss
+++ b/app/assets/stylesheets/noveus.scss
@@ -23,14 +23,16 @@
 
     
     .sell-dropbox-container {
-        height: 300px;
         padding: 40px
     }
 
+    .select-large-box {
+        display: flex;
+        width: 620px;
+    }
 
     .sell-upload-drop-box {
-        width: 620px;
-        padding: 40px;
+        width: 100%;
         position: relative;
         min-height: 162px;
         background: $background-gray;
@@ -46,44 +48,51 @@
     }
 
     p.product {
-        margin: 8px 0 0 40px;
+        margin-top: 8px;
         line-height: 1.5;
         font-weight: normal;
     }
-    b.product-title {
-        margin-left: 55px
-    }
+
+    
 
     .sell-upload-drop-box.have-item-0 {
-        width: 70%;
+        width: 620px;
         margin: 0 auto;
     }
 
+    // .sell-upload-drop-box pre {
+    //     position: absolute;
+    //     top: 50%;
+    //     left: 16px;
+    //     right: 16px;
+    //     text-align: center;
+    //     font-size: 14px;
+    //     line-height: 1.5;
+    //     -webkit-transform: translate(0, -50%);
+    //     transform: translate(0, -50%);
+    //     pointer-events: none;
+    //     white-space: pre-wrap;
+    //     word-wrap: break-word;
+    // }
 
-    .sell-upload-drop-box pre {
-        position: absolute;
-        top: 50%;
-        left: 16px;
-        right: 16px;
-        text-align: center;
-        font-size: 14px;
-        line-height: 1.5;
-        -webkit-transform: translate(0, -50%);
-        transform: translate(0, -50%);
-        pointer-events: none;
-        white-space: pre-wrap;
-        word-wrap: break-word;
-    }
+
 
     .l-left{
         width: 50%;
         line-height: 48px;
     }
 
+    .upload__images {
+        display: flex;
+        // width: 700px;
+        background: $background-gray;
+        border: 1px dashed $box-gray;
+    }
+
     .upload__image {
         width: 120px;
         height: 160px;
-        margin: 0 0 10px;
+        margin: 0 2px 12px;
         &__btn {
             height: 50px;
             line-height: 50px;

--- a/app/assets/stylesheets/noveus.scss
+++ b/app/assets/stylesheets/noveus.scss
@@ -80,6 +80,24 @@
         line-height: 48px;
     }
 
+    .upload__image {
+        width: 120px;
+        height: 160px;
+        margin: 0 0 10px;
+        &__btn {
+            height: 50px;
+            line-height: 50px;
+            background-color: #fff;
+            font-size: 12px;
+        }
+    }
+
+    #preview-image {
+        width: 120px;
+        height: 116px;
+    }
+
+    
 
     .form-require {
         background: $mercari-red;

--- a/app/assets/stylesheets/noveus.scss
+++ b/app/assets/stylesheets/noveus.scss
@@ -60,22 +60,6 @@
         margin: 0 auto;
     }
 
-    // .sell-upload-drop-box pre {
-    //     position: absolute;
-    //     top: 50%;
-    //     left: 16px;
-    //     right: 16px;
-    //     text-align: center;
-    //     font-size: 14px;
-    //     line-height: 1.5;
-    //     -webkit-transform: translate(0, -50%);
-    //     transform: translate(0, -50%);
-    //     pointer-events: none;
-    //     white-space: pre-wrap;
-    //     word-wrap: break-word;
-    // }
-
-
 
     .l-left{
         width: 50%;
@@ -84,7 +68,6 @@
 
     .upload__images {
         display: flex;
-        // width: 700px;
         background: $background-gray;
         border: 1px dashed $box-gray;
     }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -32,7 +32,7 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.require(:product).permit(:name, :description, :size_id, :condition_id, :price, :product_category_id, :delivery_responsibility, :delivery_method, :delivery_area, :delivery_day, images: []).merge(seller_id: current_user.id)
+    params.require(:product).permit(:name, :description, :size_id, :condition_id, :price, :product_category_id, :delivery_responsibility, :delivery_method, :delivery_area, :delivery_day, images: []).merge(seller_id: current_user)
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -28,7 +28,7 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.require(:product).permit(:name, :description, :size_id, :condition_id, :price, :product_category_id, :delivery_responsibility, :delivery_method, :delivery_area, :delivery_day).merge(seller_id: current_user.id)
+    params.require(:product).permit(:name, :description, :size_id, :condition_id, :price, :product_category_id, :delivery_responsibility, :delivery_method, :delivery_area, :delivery_day, images: []).merge(seller_id: current_user.id)
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -32,7 +32,7 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.require(:product).permit(:name, :description, :size_id, :condition_id, :price, :product_category_id, :delivery_responsibility, :delivery_method, :delivery_area, :delivery_day, images: []).merge(seller_id: current_user)
+    params.require(:product).permit(:name, :description, :size_id, :condition_id, :price, :product_category_id, :delivery_responsibility, :delivery_method, :delivery_area, :delivery_day, images: []).merge(seller_id: current_user.id)
   end
 
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,7 +12,8 @@ class Product < ApplicationRecord
 
   belongs_to_active_hash :prefecture
   belongs_to :product_category, optional: true
-  has_many :product_images, dependent: :destroy
+  has_many_attached :images
+  # has_many :product_images, dependent: :destroy
   belongs_to :buyer, class_name: 'User', :foreign_key => 'buyer_id', optional: true
   belongs_to :seller, class_name: 'User', :foreign_key => 'seller_id'
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -13,6 +13,7 @@ class Product < ApplicationRecord
   belongs_to_active_hash :prefecture
   belongs_to :product_category
   has_many_attached :images
+  # 画像投稿機能完成後、以下のコメントアウト削除
   # has_many :product_images, dependent: :destroy
   belongs_to :buyer, class_name: 'User', :foreign_key => 'buyer_id', optional: true
   belongs_to :seller, class_name: 'User', :foreign_key => 'seller_id'

--- a/app/views/products/_product_form.html.haml
+++ b/app/views/products/_product_form.html.haml
@@ -8,9 +8,31 @@
           .sell-dropbox-container.clearfix.state-image-number-10
             %b.product-title 商品画像
             %span.form-require 必須
-            %p.product　最大10枚までアップロードできます
-            .sell-upload-drop-box.have-item-0{onclick: "$('#pic_upload').click()"}
-              .upload__images
+            %p.product 最大10枚までアップロードできます
+            .select-large-box
+              .sell-upload-drop-box.have-item-0{onclick: "$('#pic_upload').click()"}
+              -# プレビュー画面作成のため暫定的にコメントアウト
+              -# %div.upload__images
+              -#   %li.upload__image
+              -#     %img#preview-image
+              -#     .upload__image__btn
+              -#       %a.remove-btn 削除
+              -#   %li.upload__image
+              -#     %img#preview-image
+              -#     .upload__image__btn
+              -#       %a.remove-btn 削除
+              -#   %li.upload__image
+              -#     %img#preview-image
+              -#     .upload__image__btn
+              -#       %a.remove-btn 削除
+              -#   %li.upload__image
+              -#     %img#preview-image
+              -#     .upload__image__btn
+              -#       %a.remove-btn 削除
+              -#   %li.upload__image
+              -#     %img#preview-image
+              -#     .upload__image__btn
+              -#       %a.remove-btn 削除
               -# %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
               -# %i.icon-camera
               -# \::after

--- a/app/views/products/_product_form.html.haml
+++ b/app/views/products/_product_form.html.haml
@@ -10,8 +10,11 @@
             %span.form-require 必須
             %p.product　最大10枚までアップロードできます
             .sell-upload-drop-box.have-item-0{onclick: "$('#pic_upload').click()"}
-              .preview
-              %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
+              .upload__image
+                %img#preview-image
+                .upload__image__btn 
+                  =link_to "削除", '', class: "remove-btn"
+              -# %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
               %i.icon-camera
               \::after
             = f.file_field :images, multiple: true, id: 'pic_upload', style: "display: none;"

--- a/app/views/products/_product_form.html.haml
+++ b/app/views/products/_product_form.html.haml
@@ -9,11 +9,12 @@
             %b.product-title 商品画像
             %span.form-require 必須
             %p.product　最大10枚までアップロードできます
-            .sell-upload-drop-box.have-item-0
-              %input.sell-upload-file{multiple: "", name:"image1", style: "display:none;", type: "file"}/
+            .sell-upload-drop-box.have-item-0{onclick: "$('#pic_upload').click()"}
               %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
               %i.icon-camera
               \::after
+            = f.file_field :images, multiple: true, id: 'pic_upload', style: "display: none;"
+
         .sell-content-i
           .form-group
             %label 

--- a/app/views/products/_product_form.html.haml
+++ b/app/views/products/_product_form.html.haml
@@ -10,6 +10,7 @@
             %span.form-require 必須
             %p.product　最大10枚までアップロードできます
             .sell-upload-drop-box.have-item-0{onclick: "$('#pic_upload').click()"}
+              .preview
               %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
               %i.icon-camera
               \::after

--- a/app/views/products/_product_form.html.haml
+++ b/app/views/products/_product_form.html.haml
@@ -10,13 +10,10 @@
             %span.form-require 必須
             %p.product　最大10枚までアップロードできます
             .sell-upload-drop-box.have-item-0{onclick: "$('#pic_upload').click()"}
-              .upload__image
-                %img#preview-image
-                .upload__image__btn 
-                  =link_to "削除", '', class: "remove-btn"
+              .upload__images
               -# %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
-              %i.icon-camera
-              \::after
+              -# %i.icon-camera
+              -# \::after
             = f.file_field :images, multiple: true, id: 'pic_upload', style: "display: none;"
 
         .sell-content-i

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   root "products#index"
-  resources :products, only: [:index, :show, :new, :create] do
+  resources :products, only: [:index, :show, :new, :create, :edit, :update] do
     resources :purchases, only: [:index]
 
     collection do

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,12 +7,12 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket
+amazon:
+  service: S3
+  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  region: ap-northeast-1
+  bucket: 48mercari
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,8 +9,8 @@ local:
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:
   service: S3
-  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
   region: ap-northeast-1
   bucket: 48mercari
 

--- a/db/migrate/20190804092128_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20190804092128_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_04_085952) do
+ActiveRecord::Schema.define(version: 2019_08_04_092128) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "product_brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -54,16 +75,6 @@ ActiveRecord::Schema.define(version: 2019_08_04_085952) do
     t.index ["product_category_id"], name: "index_products_on_product_category_id"
   end
 
-  create_table "shippings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "shipping_charges", null: false
-    t.string "delivery_source_area", null: false
-    t.string "days_to_delivery", null: false
-    t.bigint "product_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["product_id"], name: "index_shippings_on_product_id"
-  end
-
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -81,5 +92,5 @@ ActiveRecord::Schema.define(version: 2019_08_04_085952) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "shippings", "products"
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
 # 目的
```
  商品出品ページにて、投稿した画像をDBに保存させる。

```

 # 達成条件
```
複数枚の画像投稿・DB保存の実現。
画像のプレビュー表示は別のブランチで作業予定のため、現在は仮置きです。
```

 # 実装の概要
```
    Active Storageを使用して、画像のアップロード機能を実装しています。
(参考：https://railsguides.jp/active_storage_overview.html)
```
 # チームメンバーの方へ
```
   以下の手順で画像投稿機能の確認お願いします！
１.ログインする。
２.商品出品ページにて、出品する。
３.画像はグレーのボックスをクリックすると、ファイル選択が可能になります。複数枚選ぶこともできます。
４.プレビューは仮置きなので、１枚しか表示されません。
５.DBを確認して、「active_storage_attachments」「active_storage_blobs」にデータが入っていれば成功です。

```
![画像投稿機能テストgif](https://user-images.githubusercontent.com/49943842/62830046-a1355080-bc42-11e9-8a78-7d2457cb7567.gif)
