### PR TITLE
出品機能：投稿画像プレビュー表示機能の実装

### DIFF
--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -11,24 +11,50 @@ $(document).on('turbolinks:load', function() {
     // 画像+ボタンのひとかたまりを作る
     function appendImgBox(insertImg){
       var imagePreviewHtlm = '';
-      imagePreviewHtlm = `<div class="upload__image">
-                            ${insertImg}
-                            <div class="upload__image__btn">
-                              <a class="remove-btn">削除</a></div></div>
-                          <input multiple= "multiple" name="product[images][]" class="upload-image" data-image= "${itemNum}" type="file" id="pic_upload" style= "display: none;">
-                          <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
-      $(imagePreviewHtlm).appendTo('.select-large-box');
+      if (itemNum <= 4) {
+        imagePreviewHtlm = `<div class="upload__image">
+                              ${insertImg}
+                              <div class="upload__image__btn">
+                                <a class="remove-btn">削除</a></div></div>
+                            <input multiple= "multiple" name="product[images][]" class="upload-image" data-image= "${itemNum}" type="file" id="pic_upload" style= "display: none;">
+                            <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
+        $(imagePreviewHtlm).appendTo('#firstbox');
+      } else if (itemNum == 5) {
+        imagePreviewHtlm = `<div class="upload__image">
+                              ${insertImg}
+                              <div class="upload__image__btn">
+                                <a class="remove-btn">削除</a></div>
+                            </div>`
+        newDropBox = `<input multiple= "multiple" name="product[images][]" class="upload-image" 
+        data-image="${itemNum}" type="file" id="pic_upload" style= "display: none">
+                      <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
+        $(imagePreviewHtlm).appendTo('#firstbox');
+        $(newDropBox).appendTo('#secondbox');
+      } else if (itemNum < 10) {
+        imagePreviewHtlm = `<div class="upload__image">
+                              ${insertImg}
+                              <div class="upload__image__btn">
+                                <a class="remove-btn">削除</a></div></div>
+                            <input multiple= "multiple" name="product[images][]" class="upload-image" data-image="${itemNum}" type="file" id="pic_upload" style= "display: none;">
+                            <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
+      $(imagePreviewHtlm).appendTo('#secondbox');
+      } else {
+        imagePreviewHtlm = `<div class="upload__image">
+                              ${insertImg}
+                              <div class="upload__image__btn">
+                                <a class="remove-btn">削除</a></div></div>`
+      $(imagePreviewHtlm).appendTo('#secondbox');
+      }
       itemNum += 1;
     }
 
-
-    $('#pic_upload').change(function(e){
+    $(document).on("change", "#pic_upload",function(e){
       var files = e.target.files[0];
       var blobUrl = window.URL.createObjectURL(files);
 
       insertImg = buildImgHtml(blobUrl);
+      $('.sell-upload-drop-box').css('display', 'none');
       appendImgBox(insertImg);
-      $('.sell-upload-drop-box.have-item-0').css('display', 'none');
 
     });
 

--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -1,63 +1,61 @@
-$(document).on('turbolinks:load', function() { 
+$(function(){
+  var itemNum = 1;
+  // 画像URLをセッティング
+  function buildImgHtml(blobUrl){
+    var image = `<img src="${blobUrl}" id="preview-image">`;
+    return image;
+  }
 
-  $(function(){
-    var itemNum = 1;
-    // 画像URLをセッティング
-    function buildImgHtml(blobUrl){
-      var image = `<img src="${blobUrl}" id="preview-image">`;
-      return image;
+  // 画像+ボタンのひとかたまりを作る
+  function appendImgBox(insertImg){
+    var imagePreviewHtlm = '';
+    if (itemNum <= 4) {
+      imagePreviewHtlm = `<div class="upload__image">
+                            ${insertImg}
+                            <div class="upload__image__btn">
+                              <p class="remove-btn">削除</a></div></div>
+                          <input multiple= "multiple" name="product[images][]" class="upload-image" data-image= "${itemNum}" type="file" id="pic_upload" style= "display: none;">
+                          <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
+      $(imagePreviewHtlm).appendTo('#firstbox');
+    } else if (itemNum == 5) {
+      imagePreviewHtlm = `<div class="upload__image">
+                            ${insertImg}
+                            <div class="upload__image__btn">
+                              <p class="remove-btn">削除</a></div>
+                          </div>`
+      newDropBox = `<input multiple= "multiple" name="product[images][]" class="upload-image" 
+      data-image="${itemNum}" type="file" id="pic_upload" style= "display: none">
+                    <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
+      $(imagePreviewHtlm).appendTo('#firstbox');
+      $(newDropBox).appendTo('#secondbox');
+    } else if (itemNum < 10) {
+      imagePreviewHtlm = `<div class="upload__image">
+                            ${insertImg}
+                            <div class="upload__image__btn">
+                              <p class="remove-btn">削除</a></div></div>
+                          <input multiple= "multiple" name="product[images][]" class="upload-image" data-image="${itemNum}" type="file" id="pic_upload" style= "display: none;">
+                          <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
+    $(imagePreviewHtlm).appendTo('#secondbox');
+    } else {
+      imagePreviewHtlm = `<div class="upload__image">
+                            ${insertImg}
+                            <div class="upload__image__btn">
+                              <p class="remove-btn">削除</a></div></div>`
+    $(imagePreviewHtlm).appendTo('#secondbox');
     }
+    itemNum += 1;
+  }
 
-    // 画像+ボタンのひとかたまりを作る
-    function appendImgBox(insertImg){
-      var imagePreviewHtlm = '';
-      if (itemNum <= 4) {
-        imagePreviewHtlm = `<div class="upload__image">
-                              ${insertImg}
-                              <div class="upload__image__btn">
-                                <p class="remove-btn">削除</a></div></div>
-                            <input multiple= "multiple" name="product[images][]" class="upload-image" data-image= "${itemNum}" type="file" id="pic_upload" style= "display: none;">
-                            <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
-        $(imagePreviewHtlm).appendTo('#firstbox');
-      } else if (itemNum == 5) {
-        imagePreviewHtlm = `<div class="upload__image">
-                              ${insertImg}
-                              <div class="upload__image__btn">
-                                <p class="remove-btn">削除</a></div>
-                            </div>`
-        newDropBox = `<input multiple= "multiple" name="product[images][]" class="upload-image" 
-        data-image="${itemNum}" type="file" id="pic_upload" style= "display: none">
-                      <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
-        $(imagePreviewHtlm).appendTo('#firstbox');
-        $(newDropBox).appendTo('#secondbox');
-      } else if (itemNum < 10) {
-        imagePreviewHtlm = `<div class="upload__image">
-                              ${insertImg}
-                              <div class="upload__image__btn">
-                                <p class="remove-btn">削除</a></div></div>
-                            <input multiple= "multiple" name="product[images][]" class="upload-image" data-image="${itemNum}" type="file" id="pic_upload" style= "display: none;">
-                            <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
-      $(imagePreviewHtlm).appendTo('#secondbox');
-      } else {
-        imagePreviewHtlm = `<div class="upload__image">
-                              ${insertImg}
-                              <div class="upload__image__btn">
-                                <p class="remove-btn">削除</a></div></div>`
-      $(imagePreviewHtlm).appendTo('#secondbox');
-      }
-      itemNum += 1;
-    }
+  $(document).on("change", "#pic_upload",function(e){
+    var files = e.target.files[0];
+    var blobUrl = window.URL.createObjectURL(files);
 
-    $(document).on("change", "#pic_upload",function(e){
-      var files = e.target.files[0];
-      var blobUrl = window.URL.createObjectURL(files);
-
-      insertImg = buildImgHtml(blobUrl);
-      $('.sell-upload-drop-box').css('display', 'none');
-      appendImgBox(insertImg);
-
-    });
-
+    insertImg = buildImgHtml(blobUrl);
+    $('.sell-upload-drop-box').css('display', 'none');
+    appendImgBox(insertImg);
 
   });
+
+
 });
+

--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -15,7 +15,7 @@ $(document).on('turbolinks:load', function() {
         imagePreviewHtlm = `<div class="upload__image">
                               ${insertImg}
                               <div class="upload__image__btn">
-                                <a class="remove-btn">削除</a></div></div>
+                                <p class="remove-btn">削除</a></div></div>
                             <input multiple= "multiple" name="product[images][]" class="upload-image" data-image= "${itemNum}" type="file" id="pic_upload" style= "display: none;">
                             <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
         $(imagePreviewHtlm).appendTo('#firstbox');
@@ -23,7 +23,7 @@ $(document).on('turbolinks:load', function() {
         imagePreviewHtlm = `<div class="upload__image">
                               ${insertImg}
                               <div class="upload__image__btn">
-                                <a class="remove-btn">削除</a></div>
+                                <p class="remove-btn">削除</a></div>
                             </div>`
         newDropBox = `<input multiple= "multiple" name="product[images][]" class="upload-image" 
         data-image="${itemNum}" type="file" id="pic_upload" style= "display: none">
@@ -34,7 +34,7 @@ $(document).on('turbolinks:load', function() {
         imagePreviewHtlm = `<div class="upload__image">
                               ${insertImg}
                               <div class="upload__image__btn">
-                                <a class="remove-btn">削除</a></div></div>
+                                <p class="remove-btn">削除</a></div></div>
                             <input multiple= "multiple" name="product[images][]" class="upload-image" data-image="${itemNum}" type="file" id="pic_upload" style= "display: none;">
                             <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
       $(imagePreviewHtlm).appendTo('#secondbox');
@@ -42,7 +42,7 @@ $(document).on('turbolinks:load', function() {
         imagePreviewHtlm = `<div class="upload__image">
                               ${insertImg}
                               <div class="upload__image__btn">
-                                <a class="remove-btn">削除</a></div></div>`
+                                <p class="remove-btn">削除</a></div></div>`
       $(imagePreviewHtlm).appendTo('#secondbox');
       }
       itemNum += 1;

--- a/app/assets/javascripts/picture.js
+++ b/app/assets/javascripts/picture.js
@@ -15,9 +15,10 @@ $(document).on('turbolinks:load', function() {
                             ${insertImg}
                             <div class="upload__image__btn">
                               <a class="remove-btn">削除</a></div></div>
-                          <input multiple= "multiple" name="product[images][]" class="upload-image" data-image= "${itemNum}" type="file" id="pic_upload${itemNum}" style= "display: none;">
-                          <div class="sell-upload-drop-box" onclick= "$('#pic_upload${itemNum}').click()"></div>`
+                          <input multiple= "multiple" name="product[images][]" class="upload-image" data-image= "${itemNum}" type="file" id="pic_upload" style= "display: none;">
+                          <div class="sell-upload-drop-box" onclick= "$('[data-image= ${itemNum}]').click()"></div>`
       $(imagePreviewHtlm).appendTo('.select-large-box');
+      itemNum += 1;
     }
 
 
@@ -25,13 +26,12 @@ $(document).on('turbolinks:load', function() {
       var files = e.target.files[0];
       var blobUrl = window.URL.createObjectURL(files);
 
-
       insertImg = buildImgHtml(blobUrl);
       appendImgBox(insertImg);
       $('.sell-upload-drop-box.have-item-0').css('display', 'none');
- 
+
     });
 
-  
+
   });
 });

--- a/app/assets/stylesheets/noveus.scss
+++ b/app/assets/stylesheets/noveus.scss
@@ -80,7 +80,7 @@
             height: 50px;
             line-height: 50px;
             text-align: center;
-            background-color: #fff;
+            background-color: $background-gray;
             font-size: 12px;
         }
     }

--- a/app/assets/stylesheets/noveus.scss
+++ b/app/assets/stylesheets/noveus.scss
@@ -79,10 +79,13 @@
         &__btn {
             height: 50px;
             line-height: 50px;
+            text-align: center;
             background-color: #fff;
             font-size: 12px;
         }
     }
+
+
 
     #preview-image {
         width: 120px;

--- a/app/views/products/_product_form.html.haml
+++ b/app/views/products/_product_form.html.haml
@@ -9,30 +9,9 @@
             %b.product-title 商品画像
             %span.form-require 必須
             %p.product 最大10枚までアップロードできます
-            .select-large-box
+            .select-large-box#firstbox
               .sell-upload-drop-box.have-item-0{onclick: "$('#pic_upload').click()"}
-              -# プレビュー画面作成のため暫定的にコメントアウト
-              -# %div.upload__images
-              -#   %li.upload__image
-              -#     %img#preview-image
-              -#     .upload__image__btn
-              -#       %a.remove-btn 削除
-              -#   %li.upload__image
-              -#     %img#preview-image
-              -#     .upload__image__btn
-              -#       %a.remove-btn 削除
-              -#   %li.upload__image
-              -#     %img#preview-image
-              -#     .upload__image__btn
-              -#       %a.remove-btn 削除
-              -#   %li.upload__image
-              -#     %img#preview-image
-              -#     .upload__image__btn
-              -#       %a.remove-btn 削除
-              -#   %li.upload__image
-              -#     %img#preview-image
-              -#     .upload__image__btn
-              -#       %a.remove-btn 削除
+            .select-large-box#secondbox
               -# %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
               -# %i.icon-camera
               -# \::after

--- a/app/views/products/_product_form.html.haml
+++ b/app/views/products/_product_form.html.haml
@@ -8,13 +8,11 @@
           .sell-dropbox-container.clearfix.state-image-number-10
             %b.product-title 商品画像
             %span.form-require 必須
+            %p.product 枠内をクリックしてください
             %p.product 最大10枚までアップロードできます
             .select-large-box#firstbox
               .sell-upload-drop-box.have-item-0{onclick: "$('#pic_upload').click()"}
             .select-large-box#secondbox
-              -# %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
-              -# %i.icon-camera
-              -# \::after
             = f.file_field :images, multiple: true, id: 'pic_upload', style: "display: none;"
 
         .sell-content-i


### PR DESCRIPTION
 # 目的
```
  選んだ画像をプレビュー表示させる。
```

 # 達成条件
```
選んだ画像(1~10枚)をプレビュー表示させる。
複数枚画像の保存ができる。
```

 # チームメンバーのみなさんへ
```
プレビューが表示されるか。
画像の複数枚投稿と保存ができるか。
この２点の確認お願いします！

手順は以下の通りです。


1.ログインする。
2.グレーの枠内をクリックし、画像を１枚ずつ選択。(最大10枚まで選べます。)
3.商品名等全て入力し、出品する。
4.DBでactive_storage_attachment、active_storage_blobsテーブルにデータが保存されていれば成功です。

```

# 保留してること
```
    プレビューには削除ボタンがついていますが、実際の削除はまだできません。
```
![2cf27327722c14a34d08e408bcdc6582](https://user-images.githubusercontent.com/49943842/62908038-f000f880-bdb0-11e9-96c1-18504c3bca26.gif)