### PR TITLE
商品出品機能/バリデーションの設定

### DIFF
--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -2,7 +2,7 @@ $(function(){
   $('.input-price').on('input',function(){
     var price = $(this).val();
     if (price < 300 || price > 10000000){
-      $('#fee').text("-");
+      $('#fee').text('-');
       $('#profit').text('-');
     }else{
       var fee = Math.floor(price * 0.1);

--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -1,9 +1,14 @@
 $(function(){
   $('.input-price').on('input',function(){
     var price = $(this).val();
-    var fee = Math.floor(price * 0.1);
-    var profit = Math.ceil(price * 0.9);
-    $('#fee').text('¥' + fee);
-    $('#profit').text('¥' + profit);
+    if (price < 300 || price > 10000000){
+      $('#fee').text("-");
+      $('#profit').text('-');
+    }else{
+      var fee = Math.floor(price * 0.1);
+      var profit = Math.ceil(price * 0.9);
+      $('#fee').text('¥' + fee);
+      $('#profit').text('¥' + profit);
+    }
   })
 });

--- a/app/assets/stylesheets/noveus.scss
+++ b/app/assets/stylesheets/noveus.scss
@@ -82,6 +82,9 @@
             text-align: center;
             background-color: $background-gray;
             font-size: 12px;
+            a {
+                cursor: pointer;
+            }
         }
     }
 

--- a/app/assets/stylesheets/noveus.scss
+++ b/app/assets/stylesheets/noveus.scss
@@ -248,7 +248,7 @@ div {
 
     .l-right.price {
         height: 100%;
-        width: 50px;
+        width: 100px;
         line-height: 50px;
         font-size: 26px;
         text-align: right;
@@ -256,6 +256,7 @@ div {
 
     .l-right.price.bold {
         font-weight: bold;
+        text-align: right;
     }
 
     .l-left.price {

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -15,7 +15,7 @@ class Product < ApplicationRecord
   validates :name, {presence: true, length: {maximum: 40}}
   validates :description, {presence: true, length: {maximum: 1000}}
   validates :product_category_id, presence: true
-
+  validates :price, numericality: {greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}
 
 
   belongs_to_active_hash :prefecture, optional: true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -11,14 +11,18 @@ class Product < ApplicationRecord
 
   enum delivery_day: [:in_two_days, :in_three_days, :in_seven_days]
 
+  validates :images, presence: true
+  validates :name, {presence: true, length: {maximum: 40}}
+  validates :description, {presence: true, length: {maximum: 1000}}
+  validates :product_category_id, presence: true
+
+
 
   belongs_to_active_hash :prefecture, optional: true
   belongs_to :product_category
   belongs_to_active_hash :prefecture
   has_many :product_images, dependent: :destroy
   has_many_attached :images
-  # 画像投稿機能完成後、以下のコメントアウト削除
-  # has_many :product_images, dependent: :destroy
   belongs_to :buyer, class_name: 'User', :foreign_key => 'buyer_id', optional: true
   belongs_to :seller, class_name: 'User', :foreign_key => 'seller_id', optional: true
 end


### PR DESCRIPTION
# WHAT
- productモデルにバリデーション追加
- 価格表示の欄に条件分岐を追加

# 実装方法
- productモデルに以下のバリデーションを設定しました。
　画像無しで投稿できない。
　商品名は最大４０字。
　商品説明は最大1000字。
　カテゴリー未選択では登録できない。
　価格は300~9999999円内でのみ登録できる。

- 価格表示の欄に、300円未満・9999999円以上の時は販売手数料/販売利益が表示されないようにしました。